### PR TITLE
docs: make security pages easier to find

### DIFF
--- a/community/security-model.md
+++ b/community/security-model.md
@@ -6,6 +6,8 @@ slug: /security-model
 
 This document outlines the security model of Apache Answer. It aims to help users understand the security model and make informed decisions about deploying and managing Apache Answer securely.
 
+If you think you have found behavior in Apache Answer that does not follow this security model, please [report it](/community/security) to us privately.
+
 ## Admin Permission Security
 
 **Admin users have full system permissions**, which includes access to potentially vulnerable operations. While we assume administrators won't attack their own websites, it's crucial to exercise caution when assigning admin privileges.

--- a/community/security.md
+++ b/community/security.md
@@ -4,7 +4,7 @@ slug: /security
 
 # Security
 
-The Apache Software Foundation takes a rigorous stance on eliminating security issues in its software projects. If you find a security bug, with that in mind, please do not file public issues. You can follow the instructions in the [security policy](https://github.com/apache/answer/security/policy) to report it privately. We will fix it as soon as possible.
+The Apache Software Foundation takes a rigorous stance on eliminating security issues in its software projects. If you find a security bug, with that in mind, please do not file public issues. Before reporting a security issue, check the [security model](/community/security-model). You can follow the instructions in the [security policy](https://github.com/apache/answer/security/policy) to report it privately. We will fix it as soon as possible.
 
 # Security fixes
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ const asfLinks = [
   {to: 'https://www.apache.org/events/current-event.html', label: 'Events'},
   {to: 'https://www.apache.org/foundation/sponsorship.html', label: 'Sponsorship'},
   {to: 'https://privacy.apache.org/policies/privacy-policy-public.html', label: 'Privacy'},
-  {to: 'https://www.apache.org/security/', label: 'Security'},
+  {to: 'community/security', label: 'Security'},
   {to: 'https://www.apache.org/foundation/thanks.html', label: 'Thanks'},
 ];
 const redirectPaths = require('./redirects.js');


### PR DESCRIPTION
Add links between security pages, and don't link to the ASF-wide security page from the menu to increase the chance that a user sees the answer-specific security pages first.