### PR TITLE
Update plugins.md - update pnmp version in accordance with requirements

### DIFF
--- a/docs/getting-started/plugins.md
+++ b/docs/getting-started/plugins.md
@@ -112,7 +112,7 @@ COPY --from=answer-builder /usr/bin/answer /usr/bin/answer
 
 RUN apk --no-cache add \
     build-base git bash nodejs npm go && \
-    npm install -g pnpm@8.9.2
+    npm install -g pnpm@10.7.0
 
 RUN answer build \
     --with github.com/apache/answer-plugins/connector-basic \


### PR DESCRIPTION
- previous version listed in the docs doesn't work with current package requirements: 
```
ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
Your pnpm version is incompatible with "/go//vendor/github.com/apache/answer/ui".
Expected version: >=9
Got: 8.9.2
```